### PR TITLE
Reworked the loading indication process

### DIFF
--- a/src/styles/_browser.scss
+++ b/src/styles/_browser.scss
@@ -269,13 +269,44 @@
       flex-direction: row;
       overflow-x: hidden;
 
+      &.is-loading .asset {
+        filter: blur(3px);
+      }
+
+      &:not(.is-loading) .loader-wrapper {
+        display: none;
+      }
+
+      .loader-wrapper {
+        position: sticky;
+        top: 0;
+        left: 0;
+        width: 100%;
+        z-index: 1;
+      }
+
       .loader {
-        display: flex;
+        position: absolute;
+        left: 0;
+        top: 0;
         width: 100%;
         height: 100%;
-        justify-content: center;
-        align-items: center;
-        font-size: 16px;
+
+        &, .loader-content {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+        }
+
+        &.use-background .loader-content {
+          background: var(--mou-app-background) repeat;
+        }
+
+        .loader-content {
+          padding: 10px 25px;
+          z-index: 2;
+          font-size: 18px;
+        }
 
         i { font-size: 32px; margin-right: 10px; }
       }

--- a/src/templates/browser.hbs
+++ b/src/templates/browser.hbs
@@ -12,7 +12,14 @@
     <div class="filters-toggle {{#unless filtersVisible}}collapsed{{/unless}}"><i class="fa-solid fa-angles-{{mouIf filtersVisible "left" "right"}}"></i></div>
     <aside class="filters {{#unless filtersVisible}}collapsed{{/unless}}">{{{mouFilters}}}</aside>
     <main class="content">
-      <div class="loader"><i class="fa-regular fa-hourglass-start"></i> {{localize "MOU.loading"}}</div>
+      <div class="loader-wrapper">
+        <div class="loader">
+          <div class="loader-content">
+            <i class="fa-regular fa-hourglass-start"></i>
+            <b>{{localize "MOU.loading"}}</b>
+          </div>
+        </div>
+      </div>
     </main>
   </div>
   <div class="advanced_settings form-group">{{{ mouSettings }}}</div>

--- a/src/ts/apps/browser.ts
+++ b/src/ts/apps/browser.ts
@@ -279,7 +279,9 @@ export default class MouBrowser extends MouApplication {
   override async activateListeners(html: JQuery<HTMLElement>): Promise<void> {
     super.activateListeners(html);
     this.html = html
-    
+
+    setTimeout(() => this.showContentLoader(false))
+
     /** Very first load must be fast */
     if(this.fastLoad) {
       const filtersHTML = await this.generateFiltersHTML()
@@ -454,6 +456,21 @@ export default class MouBrowser extends MouApplication {
     this.loadMoreAssets()
   }
 
+  showContentLoader (useLoaderBackground: boolean = true) {
+    const loaderElement = this.html?.find(".content .loader")
+    if (useLoaderBackground) {
+      loaderElement?.addClass('use-background')
+    }
+
+    loaderElement?.height(this.html?.find(".content").height() || 0)
+    this.html?.find(".content").addClass('is-loading')
+  }
+
+  hideContentLoader () {
+    this.html?.find(".content").removeClass('is-loading')
+    this.html?.find(".content .loader").removeClass('use-background')
+  }
+
   /** Load more assets and activate events */
   async loadMoreAssets() {
     if(this.page < 0 || !this.collection) return
@@ -463,9 +480,13 @@ export default class MouBrowser extends MouApplication {
       if(this.page == 0) {
         assets = this.currentAssets
         this.currentAssets = []
+        this.showContentLoader()
         this.currentAssetsCount = await this.collection.getAssetsCount(this.filters)
+        this.hideContentLoader()
       } else {
+        this.showContentLoader()
         const results = await this.collection.searchAssets(this.filters, this.page);
+        this.hideContentLoader()
         if(results) {
           assets = results.assets
         }
@@ -474,8 +495,6 @@ export default class MouBrowser extends MouApplication {
       this.logError("Error loading assets:", error)
       ui.notifications?.error((game as Game).i18n.localize("MOU.error_loading_assets"));
     }
-
-    this.html?.find(".content .loader").remove()
     
     // handle collection errors (like server connection errors)
     if(this.collection.getCollectionError()) {


### PR DESCRIPTION
[The task](https://github.com/Moulinette-Craft/moulinette-foundryvtt-module/issues/21).

Work scope:
- Game world > “Moulinette Media Search”-plugin > “Moulinette Browser” | Implemented a functionality for displaying a content loader banner during the assets loading via infinite scroll
- Game world > “Moulinette Media Search”-plugin > “Moulinette Browser” | Reworked a functionality for displaying the content loader banner during the initial data loading, so that now it’s displaying functionality and UI is unified with the loading via infinite scroll

Demo:

https://github.com/user-attachments/assets/a3ce36a0-69e6-4081-b687-182203638791


