### PR TITLE
Loading indicator persists during regular browser search

### DIFF
--- a/src/ts/apps/browser.ts
+++ b/src/ts/apps/browser.ts
@@ -14,7 +14,8 @@ export default class MouBrowser extends MouApplication {
   override APP_NAME = MouBrowser.APP_NAME
 
   static PAGE_SIZE = 100
-  
+
+  private isInitialLoadCompleted: boolean = false; // Defines whether the initial app load has completed
   private fastLoad: boolean = true; // the very first load is fast, then we load assets before refreshing the page
   private loadInProgress: NodeJS.Timeout | null = null;
   private loadInProgressState: number = 0;
@@ -280,7 +281,12 @@ export default class MouBrowser extends MouApplication {
     super.activateListeners(html);
     this.html = html
 
-    setTimeout(() => this.showContentLoader(false))
+    // Display the loader only in case of the initial data loading
+    if (!this.isInitialLoadCompleted) {
+      setTimeout(() => this.showContentLoader(false))
+    }
+
+    this.isInitialLoadCompleted = true
 
     /** Very first load must be fast */
     if(this.fastLoad) {


### PR DESCRIPTION
The bug:
<img width="1047" height="181" alt="image" src="https://github.com/user-attachments/assets/49d35562-653c-4bc5-84fd-2059154b71f7" />

Work scope:
- Game world > “Moulinette Media Search”-plugin > “Moulinette Browser” > “Search” input field | Resolved an issue when the loading indicator was being shown during a regular search